### PR TITLE
Add warn support to logger.js

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -1,4 +1,4 @@
-import { bold, cyan, dim, red, green } from "kleur/colors";
+import { bold, cyan, dim, red, green, yellow } from "kleur/colors";
 
 const pkgName = "astro-critters-slim";
 
@@ -26,4 +26,8 @@ const success = (msg) => {
   console.log(`${prefix(green)} ${msg}`);
 };
 
-export default { info, error, success };
+const warn = (msg) => {
+  console.log(`${prefix(yellow)} ${msg}`);
+};
+
+export default { info, error, success, warn };


### PR DESCRIPTION
https://github.com/Suven/astro-critters/blob/main/src/index.js#L28 calls `logger.warn` but it doesn't seem to be implemented here.

When there's a warning, it causes this error:
```
02:52:45 PM [astro-critters-slim] Inlined 8.06 kB (59% of original 13.6 kB) of _astro/_slug_.3cdc04f6.css.
 error   logger.warn is not a function
  File:
    node_modules/astro-critters-slim/src/index.js:28:29
  Code:
    27 |       info: (msg) => filteredLogger(msg),
    > 28 |       warn: (msg) => logger.warn(msg),
         |                             ^
      29 |       error: (msg) => logger.error(msg),
      30 |     },
      31 |     logLevel: "info",
  Stacktrace:
TypeError: logger.warn is not a function
    at Object.warn (node_modules/astro-critters-slim/src/index.js:28:29)
    at Critters.processStyle (node_modules/critters/dist/critters.mjs:968:19)
    at node_modules/critters/dist/critters.mjs:650:48
    at Array.map (<anonymous>)
    at Critters.process (node_modules/critters/dist/critters.mjs:650:30)
    at async processFiles (node_modules/astro-critters-slim/src/index.js:37:21)
    at async withTakingALongTimeMsg (node_modules/astro/dist/integrations/index.js:17:18)
    at async runHookBuildDone (node_modules/astro/dist/integrations/index.js:265:7)
    at async AstroBuilder.build (node_modules/astro/dist/core/build/index.js:132:5)
    at async AstroBuilder.run (node_modules/astro/dist/core/build/index.js:152:7)
```

After adding the `warn` function it shows the real warning:

```
02:56:27 PM [astro-critters-slim] 1 rules skipped due to selector errors:
...
```